### PR TITLE
Fix project slug filter

### DIFF
--- a/spec/split.spec.js
+++ b/spec/split.spec.js
@@ -28,7 +28,7 @@ describe('Split', () => {
   describe('.load', () => {
     it('should request the splits', () => {
       Split.load('project/slug');
-      expect(clientFind).to.have.been.called.once.with({ 'projects.slug': 'project/slug' });
+      expect(clientFind).to.have.been.called.once.with({ filter: { 'projects.slug': 'project/slug' }});
     });
 
     it('should create the splits', (done) => {

--- a/src/split.js
+++ b/src/split.js
@@ -4,7 +4,7 @@ import { ClassificationCreatedMetric, ClassifierVisitedMetric } from './metrics'
 class Split {
   static load(slug) {
     this.clear();
-    return Client.current().findAll('split_user_variant', { 'projects.slug': slug })
+    return Client.current().findAll('split_user_variant', { filter: { 'projects.slug': slug }})
       .then((splitVariants) => {
         if (splitVariants && splitVariants.data && splitVariants.data.length > 0) {
           splitVariants.data.forEach((splitVariant) => {


### PR DESCRIPTION
I accidentally introduced a bug in #4 by misunderstanding the filter example in the devour docs. Also Seven-Ten seems to return the split I was expecting using the standard url query param, but for all projects. 

Anyway, I linked the code and deployed a staged PFE branch to test this with:

This project should get a split in the response for the `split_user_variants` endpoint request and other projects should get a 404: https://test-710.pfe-preview.zooniverse.org/projects/srallen086/workflow-assignment-testing

On master, you can see that a project that shouldn't be getting the split response is: https://master.pfe-preview.zooniverse.org/projects/srallen086/srallen-testing


